### PR TITLE
Expand canvas to full screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,10 @@
     <button id="about-btn">About</button>
     <button id="directions-btn">Directions</button>
   </div>
-  <div id="container">
-    <canvas id="game-canvas" width="800" height="600"></canvas>
-    <div id="debug"></div>
-  </div>
+    <div id="container">
+      <canvas id="game-canvas"></canvas>
+      <div id="debug"></div>
+    </div>
   <button id="auto-btn">Auto Mode</button>
 
   <div id="overlay"></div>

--- a/main.js
+++ b/main.js
@@ -5,6 +5,14 @@ import { renderGame } from './render.js';
 const canvas = document.getElementById('game-canvas');
 const ctx = canvas.getContext('2d');
 
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
+
 const GRID_ROWS = 10;
 const GRID_COLS = 10;
 const grid = initializeGrid(GRID_ROWS, GRID_COLS);

--- a/render.js
+++ b/render.js
@@ -1,17 +1,23 @@
 import { getPulses } from './pulse.js';
 
 export function renderGame(ctx, grid, options = {}) {
-  const { cellSize = 40, pending } = options;
+  const { pending } = options;
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+  const cellWidth = ctx.canvas.width / grid[0].length;
+  const cellHeight = ctx.canvas.height / grid.length;
+  const cellSize = Math.min(cellWidth, cellHeight);
 
   for (let r = 0; r < grid.length; r++) {
     for (let c = 0; c < grid[r].length; c++) {
       const cell = grid[r][c];
+      const x = c * cellWidth;
+      const y = r * cellHeight;
       if (cell.isNull) {
         ctx.fillStyle = '#000';
-        ctx.fillRect(c * cellSize, r * cellSize, cellSize - 1, cellSize - 1);
+        ctx.fillRect(x, y, cellWidth - 1, cellHeight - 1);
         ctx.strokeStyle = '#555';
-        ctx.strokeRect(c * cellSize, r * cellSize, cellSize - 1, cellSize - 1);
+        ctx.strokeRect(x, y, cellWidth - 1, cellHeight - 1);
         continue;
       }
       const intensity = 50 + cell.density * 20;
@@ -20,7 +26,7 @@ export function renderGame(ctx, grid, options = {}) {
       } else {
         ctx.fillStyle = '#222';
       }
-      ctx.fillRect(c * cellSize, r * cellSize, cellSize - 1, cellSize - 1);
+      ctx.fillRect(x, y, cellWidth - 1, cellHeight - 1);
     }
   }
 
@@ -28,8 +34,8 @@ export function renderGame(ctx, grid, options = {}) {
   for (const p of getPulses()) {
     ctx.beginPath();
     ctx.arc(
-      p.x * cellSize + cellSize / 2,
-      p.y * cellSize + cellSize / 2,
+      p.x * cellWidth + cellWidth / 2,
+      p.y * cellHeight + cellHeight / 2,
       cellSize / 4,
       0,
       Math.PI * 2
@@ -40,10 +46,10 @@ export function renderGame(ctx, grid, options = {}) {
   if (pending) {
     ctx.strokeStyle = '#fff';
     ctx.beginPath();
-    const x = pending.x * cellSize + cellSize / 2;
-    const y = pending.y * cellSize + cellSize / 2;
+    const x = pending.x * cellWidth + cellWidth / 2;
+    const y = pending.y * cellHeight + cellHeight / 2;
     ctx.moveTo(x, y);
-    ctx.lineTo(x + pending.dx * cellSize / 2, y + pending.dy * cellSize / 2);
+    ctx.lineTo(x + pending.dx * cellWidth / 2, y + pending.dy * cellHeight / 2);
     ctx.stroke();
   }
 }

--- a/style.css
+++ b/style.css
@@ -7,15 +7,18 @@ body {
 
 canvas {
   display: block;
-  margin: 40px auto 0 auto;
+  width: 100%;
+  height: 100%;
+  margin: 0;
   background: #111;
   box-shadow: 0 0 20px #00cfff;
 }
 
 #container {
   position: relative;
-  width: fit-content;
-  margin: 0 auto;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
   text-align: center;
 }
 
@@ -42,9 +45,10 @@ canvas {
 
 /* menu bar */
 #menu-bar {
-  position: absolute;
-  top: 10px;
-  right: 10px;
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  z-index: 11;
 }
 
 #menu-bar button {


### PR DESCRIPTION
## Summary
- resize canvas to fit viewport
- compute cell size from new canvas dimensions
- remove hardcoded canvas dimensions
- move menu bar to be a fixed overlay in the bottom-left

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686afda37674833089fcd0d8486d165b