### PR TITLE
Add Jest tests and brush mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ npm start              # if using a Node server
 python main.py         # if the application entry point is Python
 ```
 
+### Running Tests
+
+The repository uses **Jest** for unit testing. After installing the Node
+dependencies, run:
+
+```bash
+npm test
+```
+
+This executes all tests in the `__tests__` directory.
+
 ## Troubleshooting
 
 - **Version Mismatch**

--- a/__tests__/brush.test.js
+++ b/__tests__/brush.test.js
@@ -1,0 +1,11 @@
+import { initializeGrid } from '../grid.js';
+import { applyBrush } from '../brush.js';
+
+test('applyBrush toggles cells within radius', () => {
+  const grid = initializeGrid(3, 3);
+  applyBrush(grid, 1, 1, 1);
+  // 3x3 area toggled around center
+  expect(grid[0][0].value).toBe(1);
+  expect(grid[2][2].value).toBe(1);
+});
+

--- a/__tests__/grid.test.js
+++ b/__tests__/grid.test.js
@@ -1,0 +1,12 @@
+import { initializeGrid } from '../grid.js';
+
+test('initializeGrid creates correct dimensions', () => {
+  const grid = initializeGrid(2, 3);
+  expect(grid.length).toBe(2);
+  expect(grid[0].length).toBe(3);
+});
+
+test('cells start with default values', () => {
+  const grid = initializeGrid(1, 1);
+  expect(grid[0][0]).toEqual({ value: 0, density: 0, isNull: false });
+});

--- a/__tests__/pulse.test.js
+++ b/__tests__/pulse.test.js
@@ -1,0 +1,17 @@
+import { initializeGrid } from '../grid.js';
+import { launchPulse, updatePulse, getPulses } from '../pulse.js';
+
+describe('pulse mechanics', () => {
+  beforeEach(() => {
+    getPulses().length = 0;
+  });
+
+  test('pulse moves and toggles cell', () => {
+    const grid = initializeGrid(3, 3);
+    launchPulse(0, 0, 1, 0, 1);
+    updatePulse(1, grid);
+    expect(grid[0][1].value).toBe(1);
+    const pulses = getPulses();
+    expect(pulses[0].x).toBeCloseTo(1);
+  });
+});

--- a/brush.js
+++ b/brush.js
@@ -1,0 +1,14 @@
+export function applyBrush(grid, x, y, size = 0, type = 'toggle') {
+  for (let r = y - size; r <= y + size; r++) {
+    for (let c = x - size; c <= x + size; c++) {
+      if (r >= 0 && r < grid.length && c >= 0 && c < grid[0].length) {
+        const cell = grid[r][c];
+        if (type === 'toggle') {
+          cell.value = cell.value === 0 ? 1 : 0;
+        } else if (type === 'null') {
+          cell.isNull = !cell.isNull;
+        }
+      }
+    }
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple brush module for toggling cells
- set up Jest and add tests for grid, pulse and brush features
- document how to run tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b0d7f1430833090f00283542ab82c