### PR TITLE
Remove brush width option

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,6 @@
   <input id="zoom-range" type="range" min="5" max="60" value="20" />
 
   <div id="toolbar">
-    <label>Width
-      <input id="brush-width" type="range" min="1" max="10" value="1" />
-    </label>
     <label>Color
       <input id="brush-color" type="color" value="#00ff00" />
     </label>

--- a/main.js
+++ b/main.js
@@ -52,9 +52,7 @@ const directionsBtn = document.getElementById('directions-btn');
 const aboutPanel = document.getElementById('about-panel');
 const directionsPanel = document.getElementById('directions-panel');
 const overlay = document.getElementById('overlay');
-const brushWidthInput = document.getElementById('brush-width');
 const brushColorInput = document.getElementById('brush-color');
-let brushWidth = parseInt(brushWidthInput?.value || '1', 10);
 let brushColor = brushColorInput?.value || '#00ff00';
 let isPainting = false;
 let modifiedCells = [];
@@ -88,9 +86,8 @@ function getCellFromEvent(e) {
 
 function paintCell(e) {
   const { x, y } = getCellFromEvent(e);
-  brushWidth = parseInt(brushWidthInput.value, 10);
   brushColor = brushColorInput.value;
-  const changed = applyBrush(grid, x, y, brushWidth);
+  const changed = applyBrush(grid, x, y, 0);
   modifiedCells.push(...changed);
 }
 


### PR DESCRIPTION
## Summary
- simplify brush controls to a single-pixel brush
- remove unused width slider and related logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b13d53f38833083c5b988c6d2ddb3