### PR TITLE
Align pulses with frames

### DIFF
--- a/main.js
+++ b/main.js
@@ -107,7 +107,8 @@ window.addEventListener('mouseup', () => {
 });
 
 function loop(timestamp) {
-  const delta = (timestamp - lastTime) / 1000;
+  const FRAME_TIME = 1000 / 60;
+  const delta = (timestamp - lastTime) / FRAME_TIME;
   lastTime = timestamp;
 
   updatePulse(delta, grid);

--- a/pulse.js
+++ b/pulse.js
@@ -1,6 +1,6 @@
 const pulses = [];
 
-export function launchPulse(x, y, dx, dy, speed = 10, generation = 0) {
+export function launchPulse(x, y, dx, dy, speed = 1, generation = 0) {
   pulses.push({ x, y, dx, dy, speed, generation });
 }
 


### PR DESCRIPTION
## Summary
- synchronize pulse updates with the render framerate
- set default pulse speed so one cell moves per frame

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b15ae63208330868e60c4ce922889