### PR TITLE
Allow custom pulse color

### DIFF
--- a/__tests__/pulse.test.js
+++ b/__tests__/pulse.test.js
@@ -14,4 +14,11 @@ describe('pulse mechanics', () => {
     const pulses = getPulses();
     expect(pulses[0].x).toBeCloseTo(1);
   });
+
+  test('launchPulse stores color', () => {
+    const grid = initializeGrid(1, 1);
+    launchPulse(0, 0, 1, 0, 1, 0, '#123456');
+    const pulses = getPulses();
+    expect(pulses[0].color).toBe('#123456');
+  });
 });

--- a/main.js
+++ b/main.js
@@ -134,7 +134,7 @@ canvas.addEventListener('click', (e) => {
   clearTimeout(pendingTimeout);
   pendingTimeout = setTimeout(() => {
     if (pendingPulse) {
-      launchPulse(x, y, 1, 0);
+      launchPulse(x, y, 1, 0, 10, 0, brushColor);
       pendingPulse = null;
     }
   }, 500);
@@ -161,7 +161,15 @@ window.addEventListener('keydown', (e) => {
   if (pendingPulse) {
     const dir = getDirectionFromKey(e.key);
     if (dir) {
-      launchPulse(pendingPulse.x, pendingPulse.y, dir.dx, dir.dy);
+      launchPulse(
+        pendingPulse.x,
+        pendingPulse.y,
+        dir.dx,
+        dir.dy,
+        10,
+        0,
+        brushColor
+      );
       pendingPulse = null;
       clearTimeout(pendingTimeout);
       return;

--- a/pulse.js
+++ b/pulse.js
@@ -1,7 +1,15 @@
 const pulses = [];
 
-export function launchPulse(x, y, dx, dy, speed = 10, generation = 0) {
-  pulses.push({ x, y, dx, dy, speed, generation });
+export function launchPulse(
+  x,
+  y,
+  dx,
+  dy,
+  speed = 10,
+  generation = 0,
+  color = '#f00'
+) {
+  pulses.push({ x, y, dx, dy, speed, generation, color });
 }
 
 export function updatePulse(delta, grid) {
@@ -43,6 +51,7 @@ export function updatePulse(delta, grid) {
           dy: choice.dy,
           speed: p.speed,
           generation: p.generation + 1,
+          color: p.color,
         });
       }
     } else {

--- a/render.js
+++ b/render.js
@@ -39,8 +39,8 @@ export function renderGame(ctx, grid, options = {}) {
     }
   }
 
-  ctx.fillStyle = '#f00';
   for (const p of getPulses()) {
+    ctx.fillStyle = p.color || '#f00';
     ctx.beginPath();
     ctx.arc(
       p.x * cellWidth + cellWidth / 2,


### PR DESCRIPTION
## Summary
- keep pulse color when launched and render with that color
- ensure new pulses inherit color
- store color when launching pulses from UI
- test for stored color on pulses

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b15d39eec83309bb1f0697137a6b0