### PR TITLE
Add rapid fire mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Points are awarded for clearing patterns with as few pulses as possible.
 - **Recursive Pulses** – pulses entering dense clusters spawn additional pulses
   creating emergent behavior.
 - **Auto Mode** – toggle automatic firing using the `Auto Mode` button.
+- **Rapid Fire** – hold the middle mouse button to continuously fire pulses
+  from the cell under your cursor.
 - **Debug Panel** – live statistics appear beside the grid showing pulse count,
   active "1" cells, Null Wells and average density.
 

--- a/__tests__/pulse.test.js
+++ b/__tests__/pulse.test.js
@@ -21,4 +21,15 @@ describe('pulse mechanics', () => {
     const pulses = getPulses();
     expect(pulses[0].color).toBe('#123456');
   });
+
+  test('rapid fire launches multiple pulses', () => {
+    const grid = initializeGrid(1, 1);
+    for (let i = 0; i < 5; i++) {
+      launchPulse(0, 0, 1, 0, 1);
+    }
+    const pulses = getPulses();
+    expect(pulses.length).toBe(5);
+    updatePulse(1, grid);
+    expect(pulses[0].x).toBeCloseTo(1);
+  });
 });

--- a/main.js
+++ b/main.js
@@ -56,6 +56,9 @@ const brushColorInput = document.getElementById('brush-color');
 let brushColor = brushColorInput?.value || '#00ff00';
 let isPainting = false;
 let modifiedCells = [];
+let rapidInterval = null;
+let rapidCell = null;
+let currentDir = { dx: 1, dy: 0 };
 
 function openPanel(panel) {
   panel.classList.add('open');
@@ -92,18 +95,41 @@ function paintCell(e) {
 }
 
 canvas.addEventListener('mousedown', (e) => {
-  if (e.button !== 0) return;
-  isPainting = true;
-  paintCell(e);
+  if (e.button === 0) {
+    isPainting = true;
+    paintCell(e);
+  }
+  if (e.button === 1 && !rapidInterval) {
+    rapidCell = getCellFromEvent(e);
+    rapidInterval = setInterval(() => {
+      launchPulse(
+        rapidCell.x,
+        rapidCell.y,
+        currentDir.dx,
+        currentDir.dy,
+        10,
+        0,
+        brushColor
+      );
+    }, 100);
+  }
 });
 
 canvas.addEventListener('mousemove', (e) => {
-  if (!isPainting) return;
-  paintCell(e);
+  if (isPainting) {
+    paintCell(e);
+  }
+  if (rapidInterval) {
+    rapidCell = getCellFromEvent(e);
+  }
 });
 
 window.addEventListener('mouseup', () => {
   isPainting = false;
+  if (rapidInterval) {
+    clearInterval(rapidInterval);
+    rapidInterval = null;
+  }
 });
 
 function loop(timestamp) {
@@ -162,6 +188,7 @@ window.addEventListener('keydown', (e) => {
   if (pendingPulse) {
     const dir = getDirectionFromKey(e.key);
     if (dir) {
+      currentDir = dir;
       launchPulse(
         pendingPulse.x,
         pendingPulse.y,


### PR DESCRIPTION
## Summary
- add rapid-fire timer to fire pulses while holding the middle mouse button
- store a current direction for repeated pulses
- test multiple rapid pulse launches
- document rapid fire feature in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1739db5c8330a5d06f91cc13cbcc