### PR TITLE
Add basic 3D grid and renderer

### DIFF
--- a/__tests__/brush.test.js
+++ b/__tests__/brush.test.js
@@ -2,10 +2,10 @@ import { initializeGrid } from '../grid.js';
 import { applyBrush } from '../brush.js';
 
 test('applyBrush toggles cells within radius', () => {
-  const grid = initializeGrid(3, 3);
-  applyBrush(grid, 1, 1, 1);
-  // 3x3 area toggled around center
-  expect(grid[0][0].value).toBe(1);
-  expect(grid[2][2].value).toBe(1);
+  const grid = initializeGrid(1, 3, 3);
+  applyBrush(grid, 1, 1, 0, 1);
+  // 3x3 area toggled around center at depth 0
+  expect(grid[0][0][0].value).toBe(1);
+  expect(grid[0][2][2].value).toBe(1);
 });
 

--- a/__tests__/grid.test.js
+++ b/__tests__/grid.test.js
@@ -1,12 +1,13 @@
 import { initializeGrid } from '../grid.js';
 
 test('initializeGrid creates correct dimensions', () => {
-  const grid = initializeGrid(2, 3);
-  expect(grid.length).toBe(2);
-  expect(grid[0].length).toBe(3);
+  const grid = initializeGrid(4, 2, 3);
+  expect(grid.length).toBe(4); // depth
+  expect(grid[0].length).toBe(2); // rows
+  expect(grid[0][0].length).toBe(3); // cols
 });
 
 test('cells start with default values', () => {
-  const grid = initializeGrid(1, 1);
-  expect(grid[0][0]).toEqual({ value: 0, density: 0, isNull: false });
+  const grid = initializeGrid(1, 1, 1);
+  expect(grid[0][0][0]).toEqual({ value: 0, density: 0, isNull: false });
 });

--- a/__tests__/pulse.test.js
+++ b/__tests__/pulse.test.js
@@ -7,25 +7,25 @@ describe('pulse mechanics', () => {
   });
 
   test('pulse moves and toggles cell', () => {
-    const grid = initializeGrid(3, 3);
-    launchPulse(0, 0, 1, 0, 1);
+    const grid = initializeGrid(1, 3, 3);
+    launchPulse(0, 0, 0, 1, 0, 0, 1);
     updatePulse(1, grid);
-    expect(grid[0][1].value).toBe(1);
+    expect(grid[0][0][1].value).toBe(1);
     const pulses = getPulses();
     expect(pulses[0].x).toBeCloseTo(1);
   });
 
   test('launchPulse stores color', () => {
-    const grid = initializeGrid(1, 1);
-    launchPulse(0, 0, 1, 0, 1, 0, '#123456');
+    const grid = initializeGrid(1, 1, 1);
+    launchPulse(0, 0, 0, 1, 0, 0, 1, 0, '#123456');
     const pulses = getPulses();
     expect(pulses[0].color).toBe('#123456');
   });
 
   test('rapid fire launches multiple pulses', () => {
-    const grid = initializeGrid(1, 1);
+    const grid = initializeGrid(1, 1, 1);
     for (let i = 0; i < 5; i++) {
-      launchPulse(0, 0, 1, 0, 1);
+      launchPulse(0, 0, 0, 1, 0, 0, 1);
     }
     const pulses = getPulses();
     expect(pulses.length).toBe(5);

--- a/brush.js
+++ b/brush.js
@@ -1,15 +1,27 @@
-export function applyBrush(grid, x, y, size = 0, type = 'toggle') {
+export function applyBrush(grid, x, y, z = 0, size = 0, type = 'toggle') {
   const modified = [];
-  for (let r = y - size; r <= y + size; r++) {
-    for (let c = x - size; c <= x + size; c++) {
-      if (r >= 0 && r < grid.length && c >= 0 && c < grid[0].length) {
-        const cell = grid[r][c];
-        if (type === 'toggle') {
-          cell.value = cell.value === 0 ? 1 : 0;
-        } else if (type === 'null') {
-          cell.isNull = !cell.isNull;
+  for (let dz = -size; dz <= size; dz++) {
+    for (let dy = -size; dy <= size; dy++) {
+      for (let dx = -size; dx <= size; dx++) {
+        const nz = z + dz;
+        const ny = y + dy;
+        const nx = x + dx;
+        if (
+          nz >= 0 &&
+          nz < grid.length &&
+          ny >= 0 &&
+          ny < grid[0].length &&
+          nx >= 0 &&
+          nx < grid[0][0].length
+        ) {
+          const cell = grid[nz][ny][nx];
+          if (type === 'toggle') {
+            cell.value = cell.value === 0 ? 1 : 0;
+          } else if (type === 'null') {
+            cell.isNull = !cell.isNull;
+          }
+          modified.push({ x: nx, y: ny, z: nz });
         }
-        modified.push({ x: c, y: r });
       }
     }
   }

--- a/grid.js
+++ b/grid.js
@@ -1,11 +1,15 @@
-export function initializeGrid(rows, cols) {
+export function initializeGrid(depth, rows, cols) {
   const grid = [];
-  for (let r = 0; r < rows; r++) {
-    const row = [];
-    for (let c = 0; c < cols; c++) {
-      row.push({ value: 0, density: 0, isNull: false });
+  for (let z = 0; z < depth; z++) {
+    const plane = [];
+    for (let r = 0; r < rows; r++) {
+      const row = [];
+      for (let c = 0; c < cols; c++) {
+        row.push({ value: 0, density: 0, isNull: false });
+      }
+      plane.push(row);
     }
-    grid.push(row);
+    grid.push(plane);
   }
   return grid;
 }

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
     </div>
   </div>
 
+  <script type="module" src="https://unpkg.com/three@0.154.0/build/three.module.js"></script>
   <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/pulse.js
+++ b/pulse.js
@@ -3,13 +3,15 @@ const pulses = [];
 export function launchPulse(
   x,
   y,
+  z,
   dx,
   dy,
+  dz,
   speed = 10,
   generation = 0,
   color = '#f00'
 ) {
-  pulses.push({ x, y, dx, dy, speed, generation, color });
+  pulses.push({ x, y, z, dx, dy, dz, speed, generation, color });
 }
 
 export function updatePulse(delta, grid) {
@@ -17,38 +19,59 @@ export function updatePulse(delta, grid) {
     const p = pulses[i];
     let col = Math.floor(p.x);
     let row = Math.floor(p.y);
+    let depth = Math.floor(p.z);
     let cellSpeed = p.speed;
-    if (row >= 0 && row < grid.length && col >= 0 && col < grid[0].length) {
-      cellSpeed = p.speed - grid[row][col].density * 0.05;
+    if (
+      depth >= 0 &&
+      depth < grid.length &&
+      row >= 0 &&
+      row < grid[0].length &&
+      col >= 0 &&
+      col < grid[0][0].length
+    ) {
+      cellSpeed = p.speed - grid[depth][row][col].density * 0.05;
     }
     p.x += p.dx * cellSpeed * delta;
     p.y += p.dy * cellSpeed * delta;
+    p.z += p.dz * cellSpeed * delta;
 
     col = Math.floor(p.x);
     row = Math.floor(p.y);
+    depth = Math.floor(p.z);
 
-    if (row >= 0 && row < grid.length && col >= 0 && col < grid[0].length) {
-      const cell = grid[row][col];
+    if (
+      depth >= 0 &&
+      depth < grid.length &&
+      row >= 0 &&
+      row < grid[0].length &&
+      col >= 0 &&
+      col < grid[0][0].length
+    ) {
+      const cell = grid[depth][row][col];
       if (cell.isNull) {
         pulses.splice(i, 1);
         continue;
       }
       cell.value = cell.value === 0 ? 1 : 0;
 
-      const neighbors = countOnNeighbors(grid, row, col);
+      const neighbors = countOnNeighbors(grid, depth, row, col);
       if (neighbors >= 3 && p.generation < 5) {
         const dirs = [
-          { dx: 1, dy: 0 },
-          { dx: -1, dy: 0 },
-          { dx: 0, dy: 1 },
-          { dx: 0, dy: -1 },
+          { dx: 1, dy: 0, dz: 0 },
+          { dx: -1, dy: 0, dz: 0 },
+          { dx: 0, dy: 1, dz: 0 },
+          { dx: 0, dy: -1, dz: 0 },
+          { dx: 0, dy: 0, dz: 1 },
+          { dx: 0, dy: 0, dz: -1 },
         ];
         const choice = dirs[Math.floor(Math.random() * dirs.length)];
         pulses.push({
           x: p.x,
           y: p.y,
+          z: p.z,
           dx: choice.dx,
           dy: choice.dy,
+          dz: choice.dz,
           speed: p.speed,
           generation: p.generation + 1,
           color: p.color,
@@ -64,21 +87,26 @@ export function getPulses() {
   return pulses;
 }
 
-function countOnNeighbors(grid, r, c) {
+function countOnNeighbors(grid, z, r, c) {
   let count = 0;
-  for (let dr = -1; dr <= 1; dr++) {
-    for (let dc = -1; dc <= 1; dc++) {
-      if (dr === 0 && dc === 0) continue;
-      const nr = r + dr;
-      const nc = c + dc;
-      if (
-        nr >= 0 &&
-        nr < grid.length &&
-        nc >= 0 &&
-        nc < grid[0].length &&
-        grid[nr][nc].value === 1
-      ) {
-        count++;
+  for (let dz = -1; dz <= 1; dz++) {
+    for (let dr = -1; dr <= 1; dr++) {
+      for (let dc = -1; dc <= 1; dc++) {
+        if (dz === 0 && dr === 0 && dc === 0) continue;
+        const nz = z + dz;
+        const nr = r + dr;
+        const nc = c + dc;
+        if (
+          nz >= 0 &&
+          nz < grid.length &&
+          nr >= 0 &&
+          nr < grid[0].length &&
+          nc >= 0 &&
+          nc < grid[0][0].length &&
+          grid[nz][nr][nc].value === 1
+        ) {
+          count++;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- add depth dimension to grid and pulses
- switch rendering to simple Three.js scene
- update input & main loop for 3D
- adjust unit tests for new grid and movement logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b9bd6688330b46ad824c7585b1d