### PR TITLE
Add z-depth to pulses

### DIFF
--- a/__tests__/pulse.test.js
+++ b/__tests__/pulse.test.js
@@ -8,7 +8,7 @@ describe('pulse mechanics', () => {
 
   test('pulse moves and toggles cell', () => {
     const grid = initializeGrid(1, 3, 3);
-    launchPulse(0, 0, 1, 0, 1);
+    launchPulse(0, 0, 0, 1, 0, 1);
     updatePulse(1, grid[0]);
     expect(grid[0][0][1].value).toBe(1);
     const pulses = getPulses();
@@ -17,7 +17,7 @@ describe('pulse mechanics', () => {
 
   test('launchPulse stores color', () => {
     const grid = initializeGrid(1, 1, 1);
-    launchPulse(0, 0, 1, 0, 1, 0, '#123456');
+    launchPulse(0, 0, 0, 1, 0, 1, 0, '#123456');
     const pulses = getPulses();
     expect(pulses[0].color).toBe('#123456');
   });
@@ -25,7 +25,7 @@ describe('pulse mechanics', () => {
   test('rapid fire launches multiple pulses', () => {
     const grid = initializeGrid(1, 1, 1);
     for (let i = 0; i < 5; i++) {
-      launchPulse(0, 0, 1, 0, 1);
+      launchPulse(0, 0, 0, 1, 0, 1);
     }
     const pulses = getPulses();
     expect(pulses.length).toBe(5);

--- a/main.js
+++ b/main.js
@@ -92,6 +92,7 @@ canvas.addEventListener('mousedown', (e) => {
       launchPulse(
         rapidCell.x,
         rapidCell.y,
+        rapidCell.z,
         currentDir.dx,
         currentDir.dy,
         10,
@@ -145,7 +146,7 @@ canvas.addEventListener('click', (e) => {
   clearTimeout(pendingTimeout);
   pendingTimeout = setTimeout(() => {
     if (pendingPulse) {
-      launchPulse(x, y, 1, 0, 10, 0, brushColor);
+      launchPulse(x, y, z, 1, 0, 10, 0, brushColor);
       pendingPulse = null;
     }
   }, 500);
@@ -177,6 +178,7 @@ window.addEventListener('keydown', (e) => {
       launchPulse(
         pendingPulse.x,
         pendingPulse.y,
+        pendingPulse.z,
         dir.dx,
         dir.dy,
         10,
@@ -213,7 +215,7 @@ autoBtn.addEventListener('click', () => {
         { dx: 0, dy: 0, dz: -1 },
       ];
       const d = dirs[Math.floor(Math.random() * dirs.length)];
-      launchPulse(x, y, d.dx, d.dy);
+      launchPulse(x, y, Math.floor(GRID_DEPTH / 2), d.dx, d.dy);
     }, 250);
     autoBtn.textContent = 'Pause Auto';
   }

--- a/pulse.js
+++ b/pulse.js
@@ -3,13 +3,14 @@ const pulses = [];
 export function launchPulse(
   x,
   y,
+  z = 0,
   dx,
   dy,
   speed = 10,
   generation = 0,
   color = '#f00'
 ) {
-  pulses.push({ x, y, dx, dy, speed, generation, color });
+  pulses.push({ x, y, z, dx, dy, speed, generation, color });
 }
 
 export function updatePulse(delta, grid) {


### PR DESCRIPTION
## Summary
- allow `launchPulse` to accept a `z` argument and store it on pulses
- pass z position when launching pulses
- update pulse tests for new signature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b22da42148330a973f4bc4bb45f9f