### PR TITLE
Use active grid plane when updating pulses

### DIFF
--- a/main.js
+++ b/main.js
@@ -125,7 +125,7 @@ function loop(timestamp) {
   const delta = (timestamp - lastTime) / FRAME_TIME;
   lastTime = timestamp;
 
-  updatePulse(delta, grid);
+  updatePulse(delta, grid[Math.floor(GRID_DEPTH / 2)]);
   renderGame(grid);
   modifiedCells = [];
   updateDebug();


### PR DESCRIPTION
## Summary
- fix `updatePulse` call to operate on the active grid plane

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b24124f50833081f48626130e7628