### PR TITLE
Update README for CDN requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Open `index.html` directly in your browser or serve the files with a simple stat
 npx http-server .
 ```
 
+**Note:** `index.html` loads the Three.js library from a CDN. You need an
+active internet connection when opening the file unless you download
+`three.module.js` locally and update the script tag accordingly.
+
 ### Running Tests
 
 The repository uses **Jest** for unit testing. After installing the Node


### PR DESCRIPTION
## Summary
- clarify that loading index.html requires a network connection if the Three.js dependency isn't stored locally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b24e78a6c83309c847a76162f16f3