### PR TITLE
Fix missing brush cursor

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,7 +14,7 @@ canvas {
   margin: 0;
   background: #111;
   box-shadow: 0 0 20px #00cfff;
-  cursor: url('brush.png') 4 4, crosshair;
+  cursor: crosshair;
 }
 
 #container {


### PR DESCRIPTION
## Summary
- remove the unused `brush.png` cursor reference

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2856aec08330843a035704077920